### PR TITLE
fix: add --preserve-env=PATH to sudo command

### DIFF
--- a/local/quick-start/start.sh
+++ b/local/quick-start/start.sh
@@ -37,7 +37,7 @@ consul agent -dev \
 # https://github.com/deislabs/hippo/blob/de73ae52d606c0a2351f90069e96acea831281bc/src/Infrastructure/Jobs/NomadJob.cs#L28
 # https://www.nomadproject.io/docs/drivers/exec#client-requirements
 case "$OSTYPE" in
- linux*) SUDO=sudo ;;
+ linux*) SUDO="sudo --preserve-env=PATH" ;;
  *) SUDO= ;;
 esac
 


### PR DESCRIPTION
This ensures that Nomad inherits the current user's PATH environment variable,
rather that the default sudo behavior of using a sanitized PATH.

This is necessary because the user may have installed bindle-server, traefik,
etc. locally but not system-wide. For example, cargo install installs in the
current user's home directory by default.

Signed-off-by: Joel Dice <joel.dice@gmail.com>