### PR TITLE
Updating Hippo to v0.16.3 for local installer

### DIFF
--- a/local/job/hippo.nomad
+++ b/local/job/hippo.nomad
@@ -12,7 +12,7 @@ variable "bindle_url" {
 
 variable "hippo_version" {
   type        = string
-  default     = "v0.15.1"
+  default     = "v0.16.3"
   description = "Hippo version"
 }
 


### PR DESCRIPTION
Signed-off-by: Mikkel Mørk Hegnhøj <mikkel@fermyon.com>

Fixes removing Nomad jobs form Hippo (and probably more).