### PR TITLE
start hippo job with raw_exec driver

### DIFF
--- a/local/job/hippo.nomad
+++ b/local/job/hippo.nomad
@@ -26,15 +26,6 @@ variable "os" {
   }
 }
 
-variable "driver" {
-  type = string
-  default = "raw_exec"
-  validation {
-    condition = var.driver == "raw_exec" || var.driver == "exec"
-    error_message = "Invalid value for driver; valid values are [raw_exec, exec]."
-  }
-}
-
 job "hippo" {
   datacenters = ["dc1"]
   type        = "service"
@@ -64,7 +55,7 @@ job "hippo" {
     }
 
     task "hippo" {
-      driver = var.driver
+      driver = "raw_exec"
 
       artifact {
         source = "https://github.com/deislabs/hippo/releases/download/${var.hippo_version}/hippo-server-${var.os}-x64.tar.gz"

--- a/local/start.sh
+++ b/local/start.sh
@@ -74,7 +74,7 @@ case "${OSTYPE}" in
     nomad run -var="os=osx" job/hippo.nomad
     ;;
   linux*)
-    nomad run -var="os=linux" -var="driver=exec" job/hippo.nomad
+    nomad run -var="os=linux" job/hippo.nomad
     ;;
   *)
     echo "Hippo is only started on MacOS and Linux"


### PR DESCRIPTION
See https://github.com/fermyon/nomad-local-demo/blob/579af01653c5a365047577869dec119c6529a4c3/job/hippo-linux.nomad#L43

closes #36 