### PR TITLE
docs(*): re-org and add unified deploy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ways to deploy ("install") Fermyon in their preferred environment.
 
 Fermyon runs on [Nomad](https://nomadproject.io), so deployment scenarios
 will first configure and install this software, in tandem with
-[Consul](https://consul.io) and [Vault](https://vaultproject.io).
+[Consul](https://consul.io).
 
 Afterwards, the components comprising Fermyon are deployed in the
 form of Nomad jobs, including a [Bindle](https://github.com/deislabs/bindle)
@@ -18,18 +18,36 @@ server, [Traefik](https://docs.traefik.io) as the reverse proxy/load balancer
 and [Hippo](https://github.com/deislabs/hippo), the web UI for managing
 Spin-based applications.
 
-## Quick-starts
+# Installers
 
-### AWS
+## Local
+---
 
-The [AWS Quick-start](./aws/quick-start) utilizes
-[Terraform](https://terraform.io) to deploy a lightweight, working example
-of Fermyon on AWS. This is a great route to go for quickly testing out the
-platform, as it only creates the minimal array of AWS resources needed to run
-the services.
+Looking to install Fermyon on your local machine? Follow the
+[local](./local/README.md) guide to get started.
 
-Users will be able to interact with publicly-accessible Bindle and Hippo
-services within 5 minutes of starting the deployment and can then start
-deploying their applications.
+Once the
+[prerequisites](./local/README.md#prerequisites) have been installed, this
+is the quickest and easiest method to launch Fermyon and begin deploying
+apps.
 
-To get started, head over to the [README.md](./aws/quick-start/README.md).
+## AWS
+---
+
+The [AWS Quick-start](./aws/README.md) is a great option to go if you'd like
+to run Fermyon in a separate environment.
+
+This installer utilizes [Terraform](https://terraform.io) to deploy a
+lightweight, working example of Fermyon on AWS, using only a minimal array of
+resources needed to run the services.
+
+You'll be able to interact with publicly-accessible Bindle and Hippo services
+within 5 minutes of invoking `terraform apply`. From there, you can start
+deploying your applications.
+
+# Deploying to Fermyon
+
+After installing Fermyon in your preferred environment, you are ready to deploy
+your first application.
+
+Follow the [deploy guide](../deploy.md) to get started.

--- a/aws/README.md
+++ b/aws/README.md
@@ -32,7 +32,6 @@ is enabled, apps will be provided with https URLs and TLS certs courtesy LE.
 
 - The [terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli#install-terraform)
 
-- The [Spin CLI](https://spin.fermyon.dev/quickstart)
 
 # Resources deployed
 
@@ -98,26 +97,20 @@ Let's Encrypt may incur a rate limit on your domain. Create the A record for *.e
 making sure it points to the Elastic IP's public address.
 See https://letsencrypt.org/docs/staging-environment/#rate-limits for more details.
 
-# Interacting with Fermyon
+## Environment estup
 
-Once this example has been deployed, you're ready to start building and deploying applications
-on Fermyon.
+When Terraform finishes provisioning, it will supply URL and username/password
+values for Hippo and Bindle, which will be needed to deploy your first
+application.
 
-For in-depth guides, follow the [Spin documentation](https://spin.fermyon.dev/) or
-[Hippo documentation](https://docs.hippofactory.dev/) to get started.
-
-## Example flow
-
-Here's an example flow once `terraform apply` completes.
-
-First, export pertinent environment variables using the `environment` output:
+Set your environment up in one go using the `environment` output:
 
 ```console
 $(terraform output -raw environment)
 ```
 
-This will export the following environment variables, for use by the CLIs and example
-commands below:
+This will export values into your shell for the following environment
+variables:
 
   - `DNS_DOMAIN`
   - `HIPPO_USERNAME`
@@ -125,57 +118,9 @@ commands below:
   - `HIPPO_URL`
   - `BINDLE_URL`
 
-Next, you're ready to log in to Hippo, create a new Spin app and deploy to Hippo.
 
-```console
-$ hippo login
-Logged in as admin
-
-$ spin templates install --git https://github.com/fermyon/spin
-Copying remote template source
-Installing template redis-rust...
-Installing template http-rust...
-Installing template http-go...
-Installing template redis-go...
-Installed 4 template(s)
-
-+---------------------------------------------------+
-| Name         Description                          |
-+===================================================+
-| http-go      HTTP request handler using (Tiny)Go  |
-| http-rust    HTTP request handler using Rust      |
-| redis-go     Redis message handler using (Tiny)Go |
-| redis-rust   Redis message handler using Rust     |
-+---------------------------------------------------+
-
-$ spin new http-rust myapp
-Project description: My first Fermyon app
-HTTP base: /
-HTTP path: /hello
-
-$ cd myapp/
-
-$ spin build
-<build output omitted>
-
-$ spin deploy
-Successfully deployed application!
-```
-
-You can then hit your app's served route (`/hello`) via its URL.
-
-The default structure for an app's URL on Hippo is `http(s)://<channel name>.<app name>.hippo.<domain>`.
-When deploying with `spin deploy`, the app name is used for the hippo channel name as well.
-
-You can also find the app URL by navigating to the Hippo dashboard (`$HIPPO_URL`), loggging in
-with the `$HIPPO_USERNAME` and `$HIPPO_PASSWORD` values and then clicking on the app page.
-
-Here's what the URL looks like based on the example above:
-
-```console
-$ curl http://myapp.myapp.hippo.${DNS_DOMAIN}/hello
-Hello, Fermyon
-```
+Now you're ready to start building and deploying applications on Fermyon!
+Follow the [Deploying to Fermyon](../deploy.md) guide for the next steps.
 
 ## Cleaning up
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -97,7 +97,7 @@ Let's Encrypt may incur a rate limit on your domain. Create the A record for *.e
 making sure it points to the Elastic IP's public address.
 See https://letsencrypt.org/docs/staging-environment/#rate-limits for more details.
 
-## Environment estup
+## Environment setup
 
 When Terraform finishes provisioning, it will supply URL and username/password
 values for Hippo and Bindle, which will be needed to deploy your first

--- a/deploy.md
+++ b/deploy.md
@@ -1,0 +1,105 @@
+# Deploying to Fermyon
+
+Once Fermyon is up and running via your
+[installer of choice](./README.md#installers) and you've prepared your
+environment with relevant values for Hippo and Bindle, you're ready to deploy
+your first app.
+
+## Prerequisites
+
+For building and deploying Spin apps on Fermyon, you'll need the
+[Spin CLI](https://spin.fermyon.dev/quickstart).
+
+## Example flow
+
+First, install the example application templates via Spin:
+
+```console
+$ spin templates install --git https://github.com/fermyon/spin
+Copying remote template source
+Installing template redis-rust...
+Installing template http-rust...
+Installing template http-go...
+Installing template redis-go...
+Installed 4 template(s)
+
++---------------------------------------------------+
+| Name         Description                          |
++===================================================+
+| http-go      HTTP request handler using (Tiny)Go  |
+| http-rust    HTTP request handler using Rust      |
+| redis-go     Redis message handler using (Tiny)Go |
+| redis-rust   Redis message handler using Rust     |
++---------------------------------------------------+
+```
+
+Here we'll choose the `http-rust` example and create a new app:
+
+```console
+$ spin new http-rust myapp
+Project description: My first Fermyon app
+HTTP base: /
+HTTP path: /hello
+```
+
+You're ready to navigate into the app directory and build it from source:
+
+```console
+$ cd myapp/
+
+$ spin build
+<build output omitted>
+```
+
+Finally, you are ready to deploy:
+
+```console
+$ spin deploy
+Deployed myapp version 0.1.0+q65c7318
+Available Routes:
+  myapp: http://spin-deploy.myapp.local.fermyon.link/hello
+```
+
+You can then hit your app's served route (`/hello`) via its URL.
+
+```console
+$ curl http://spin-deploy.myapp.local.fermyon.link/hello
+Hello, Fermyon
+```
+
+You can also find the app URL by navigating to the Hippo dashboard (`$HIPPO_URL`), loggging in
+with the `$HIPPO_USERNAME` and `$HIPPO_PASSWORD` values and then clicking on the app page.
+
+Congratulations, you've deployed your first Fermyon app!
+
+## Deploying new versions of your app
+
+Making changes to your app is as easy as updating the source code, re-building
+and re-deploying.
+
+To see this in practice, update the message to `Hello, Fermyon!` in the app's
+source code and save your changes. After a fresh build and deploy, the
+new version of your app will be live:
+
+```console
+$ spin build
+<build output omitted>
+
+$ spin deploy
+Deployed myapp version 0.1.0+qdb204e5
+Available Routes:
+  myapp: http://spin-deploy.myapp.local.fermyon.link/hello
+
+$ curl http://spin-deploy.myapp.local.fermyon.link/hello
+Hello, Fermyon!
+```
+
+## Wrapping up
+
+In this guide, we walked through deploying multiple versions of your first
+application on Fermyon.
+
+We hope this experience inspires you to explore further. For in-depth guides
+and further information, see the
+[Spin documentation](https://spin.fermyon.dev/) or
+[Hippo documentation](https://docs.hippofactory.dev/).

--- a/local/README.md
+++ b/local/README.md
@@ -9,12 +9,29 @@ The environment is ephemeral and will not persist any data.
 
 # Prerequisites
 
-[Nomad](https://www.nomadproject.io/docs/install)
-[Consul](https://www.consul.io/docs/install)
-[Spin CLI](https://spin.fermyon.dev/quickstart)
+- [Nomad](https://www.nomadproject.io/docs/install)
+- [Consul](https://www.consul.io/docs/install)
 
 # How to Deploy
 
 ```console
 ./start.sh
 ```
+
+# Deploying to Fermyon
+
+Once the script finishes deploying Fermyon services it will print a list of
+export statements. Copy these to your clipboard, leave the script running and
+open a new terminal window.
+
+Next, navigate your browser to Hippo (e.g. `open $HIPPO_URL`) and register a
+new account. The username and password values will be needed when deploying
+your Spin application, so export these into your terminal as well:
+
+```console
+export HIPPO_USERNAME=<username>
+export HIPPO_PASSWORD=<password>
+```
+
+Now you are ready to deploy your first application on Fermyon. Follow the
+[guide to get started](../deploy.md).


### PR DESCRIPTION
* Re-orgs installer docs and adds a unified app deploy guide

Closes https://github.com/fermyon/installer/issues/30