### PR TITLE
feat(aws): apply common tags to all resources

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -51,6 +51,12 @@ This example creates the following resources in the provided AWS account:
     - Name: `${var.instance_name}_ssh_key_pair`
     - see `var.allowed_ssh_cidr_blocks` for allowed origin IP addresses
 
+> All resources are tagged with a common set of tags, in addition to any
+resource-specific tags that might be defined. This enables
+[searching for resources based on tags](https://docs.aws.amazon.com/ARG/latest/userguide/tag-editor.html)
+and can be helpful if manual cleanup is necessary.
+To see these applied tags, run `terraform output common_tags`.
+
 # Security disclaimer
 
 By default, the allowed inbound and SSH CIDR block is `0.0.0.0/0` aka The Entire Internet.

--- a/aws/terraform/main.tf
+++ b/aws/terraform/main.tf
@@ -23,6 +23,10 @@ locals {
 
   hippo_version    = "v0.17.0"
   hippo_checksum   = "2a9690cd8546108fbd27a9f0c4898d1c2c171a76219803290b526e40da1c3211"
+
+  common_tags = {
+    FermyonInstallation = var.instance_name
+  }
 }
 
 # -----------------------------------------------------------------------------
@@ -61,9 +65,12 @@ data "aws_vpc" "default" {
 resource "aws_eip" "lb" {
   vpc = true
 
-  tags = {
-    Name = "${var.instance_name}-eip"
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.instance_name}-eip"
+    }
+  )
 }
 
 resource "aws_eip_association" "lb" {
@@ -134,9 +141,12 @@ resource "aws_instance" "ec2" {
 
   vpc_security_group_ids = [aws_security_group.ec2.id]
 
-  tags = {
-    Name = var.instance_name
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = var.instance_name
+    }
+  )
 }
 
 # -----------------------------------------------------------------------------
@@ -147,9 +157,12 @@ resource "aws_security_group" "ec2" {
   name_prefix = var.instance_name
   vpc_id      = data.aws_vpc.default.id
 
-  tags = {
-    Name = "${var.instance_name}-security-group"
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${var.instance_name}-security-group"
+    }
+  )
 
   lifecycle {
     create_before_destroy = true
@@ -233,6 +246,8 @@ resource "tls_private_key" "ec2_ssh_key" {
 resource "aws_key_pair" "ec2_ssh_key_pair" {
   key_name   = "${var.instance_name}_ssh_key_pair"
   public_key = tls_private_key.ec2_ssh_key.public_key_openssh
+
+  tags = local.common_tags
 }
 
 # -----------------------------------------------------------------------------

--- a/aws/terraform/outputs.tf
+++ b/aws/terraform/outputs.tf
@@ -40,6 +40,11 @@ output "hippo_admin_password" {
   sensitive   = true
 }
 
+output "common_tags" {
+  description = "All applicable AWS resources are tagged with these values"
+  value       = local.common_tags
+}
+
 output "environment" {
   description = "Get environment config by running: $(terraform output -raw environment)"
   sensitive   = true


### PR DESCRIPTION
* Adds a set of `common_tags` (in this PR currently we just have one) to be applied to all resources, enabling manual cleanup if needed.

Two considerations:
 - I initially started down the [default_tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider) path; however, with this approach, the tag values need to be known prior to apply, i.e. static.  If we're okay with something static like `"FermyonInstaller" = true`, then we could go this route and it would clean up the code a bit (remove the `merge` of common_tags and resource-specific tags)
 - @lann initially suggested a tag with a timestamp as a value.  I opted not to go this route as it would both require updates to all applicable resources on any/every `terraform apply` and the tag value itself didn't seem conducive to search with... however, I'm open to pushback on this if we think tracking installation (or, update) times would be helpful.

Closes https://github.com/fermyon/installer/issues/68