### PR TITLE
Statically link vendored Linux `bindle-server`

### DIFF
--- a/local/bindle/Dockerfile.bindle-static
+++ b/local/bindle/Dockerfile.bindle-static
@@ -1,8 +1,8 @@
 # Build with buster to support running on oldish releases
-FROM rust:1.61-slim-buster as build
+FROM rust:1.62-alpine as build
 
 # Prepare build environment
-RUN apt-get update && apt-get install -y wget libssl-dev pkg-config make perl clang
+RUN apk add --no-cache libc-dev pkgconfig openssl-dev perl make
 
 # Fetch bindle source
 WORKDIR /usr/src/bindle
@@ -12,8 +12,7 @@ WORKDIR bindle-0.8.0
 RUN cargo update
 
 # Link openssl statically to support Ubuntu 22.04+
-RUN cargo install cargo-edit
-RUN cargo add openssl@0.10 +vendored
+RUN cargo add openssl@0.10.40 --features vendored
 
 RUN cargo build \
         --release \

--- a/local/job/bindle.nomad
+++ b/local/job/bindle.nomad
@@ -59,7 +59,7 @@ job "bindle" {
 
       artifact {
         source = lookup({
-          linux="https://raw.githubusercontent.com/fermyon/installer/9fca2d7b641440cef0f75d38ace9cd3128b5a8a3/local/bindle/bindle-server"
+          linux="https://raw.githubusercontent.com/fermyon/installer/93008bc6461076da5c5f7f99cffc3e68b1955a17/local/bindle/bindle-server"
         }, var.os, "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-${var.os}-${var.arch}.tar.gz")
       }
 


### PR DESCRIPTION
This should resolve any glibc compat issues.