### PR TITLE
Update vault status command

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -206,7 +206,7 @@ traefik  service  50        running  2022-05-18T23:42:31Z
 ### Check Vault
 
 ```console
-ubuntu@ip-10-0-0-12:~$ vault status
+ubuntu@ip-10-0-0-12:~$ vault status -address http://127.0.0.1:8200
 Key             Value
 ---             -----
 Seal Type       shamir


### PR DESCRIPTION
Vault is not currently configured to use a certificate. You need to configure the status command to hit the HTTP endpoint rather than the HTTPS endpoint.

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>

Before change
```shell
ubuntu@myfermyonvm:~$ vault status
Error checking seal status: Get "https://127.0.0.1:8200/v1/sys/seal-status": http: server gave HTTP response to HTTPS client
```

After change
```shell
ubuntu@myfermyonvm:~$ vault status -address http://127.0.0.1:8200
Key             Value
---             -----
Seal Type       shamir
Initialized     true
Sealed          false
Total Shares    1
Threshold       1
Version         1.10.3
Storage Type    file
Cluster Name    vault-cluster-268aeb56
Cluster ID      cf18c03a-b14e-ecf4-895f-33643ba4833a
HA Enabled      false
```