### PR TITLE
bump to hippo v0.19.0

### DIFF
--- a/azure/terraform/main.tf
+++ b/azure/terraform/main.tf
@@ -21,8 +21,8 @@ locals {
   spin_version  = "v0.4.0"
   spin_checksum = "0d8f087b751bb26c43bcc45dbe0e9283da189df73ea55140efc4e3958855a7d6"
 
-  hippo_version  = "v0.17.0"
-  hippo_checksum = "2a9690cd8546108fbd27a9f0c4898d1c2c171a76219803290b526e40da1c3211"
+  hippo_version  = "v0.19.0"
+  hippo_checksum = "ec1619756897cbe4cae7789eee6787cf472cb14b439c00b9be0de1fea08a1a49"
 
   common_tags = {
     FermyonInstallation = "localtest"

--- a/local/job/hippo.nomad
+++ b/local/job/hippo.nomad
@@ -12,7 +12,7 @@ variable "bindle_url" {
 
 variable "hippo_version" {
   type        = string
-  default     = "v0.17.0"
+  default     = "v0.19.0"
   description = "Hippo version"
 }
 

--- a/share/terraform/dependencies.yaml
+++ b/share/terraform/dependencies.yaml
@@ -2,7 +2,7 @@ nomad:
   version: "1.3.1"
   checksum: "d16dcea9fdfab3846e749307e117e33a07f0d8678cf28cc088637055e34e5b37"
 
-consul: 
+consul:
   version: "1.12.1"
   checksum: "8d138267701fc3502dc6b01beb08ae8fac969022ab867f61bc945af38686ecc3"
 
@@ -23,5 +23,5 @@ spin:
   checksum: "0d8f087b751bb26c43bcc45dbe0e9283da189df73ea55140efc4e3958855a7d6"
 
 hippo:
-  version: "v0.17.0"
-  checksum: "2a9690cd8546108fbd27a9f0c4898d1c2c171a76219803290b526e40da1c3211"
+  version: "v0.19.0"
+  checksum: "ec1619756897cbe4cae7789eee6787cf472cb14b439c00b9be0de1fea08a1a49"


### PR DESCRIPTION
To be merged after https://github.com/fermyon/spin/pull/678 is merged and a new release of spin becomes available.