### PR TITLE
Added an early exit for unsupported OS environments

### DIFF
--- a/local/start.sh
+++ b/local/start.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Early exit for unsupported systems
+case "${OSTYPE}" in
+  linux* | darwin*)
+    ;; # Linux, MacOS, and WSL2 can proceed
+  msys | cgywin)
+    echo "The ${OSTYPE} environment is not yet supported for the Fermyon platform."
+    echo "But it will work within the Windows Subsystem for Linux."
+    echo "See https://docs.microsoft.com/en-us/windows/wsl/install for details."
+    exit 1
+    ;;
+  *)
+    echo "The ${OSTYPE} environment is not yet supported for the Fermyon platform."
+    exit 1
+    ;;
+esac
+
 require() {
   if ! hash "$1" &>/dev/null; then
     echo "'$1' not found in PATH"


### PR DESCRIPTION
This is a first-time user experience improvement.

Since nomad, consul, and spin all have native Windows releases,
running the installer from a Windows git bash environment (msys) sort of works,
but the traefik job fails internally, without a clear reason in the console (other than "it took too long").

The source of the failure is buried in the nomad.log, since the traefik component download 404-ed
because the windows release is a zip, not a tar.gz.

The added OS environment check at the start of the platform installer will point n00bs in the right direction.