### PR TITLE
Update vault status command in gcp readme

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -185,7 +185,7 @@ traefik  service  50        running  2022-06-30T08:44:01Z
 ### Check Vault
 
 ```console
-ubuntu@fermyon:~$ vault status
+ubuntu@fermyon:~$ vault status -address http://127.0.0.1:8200
 Key             Value
 ---             -----
 Seal Type       shamir


### PR DESCRIPTION
Vault is not currently configured to use a certificate. You need to configure the status command to hit the HTTP endpoint rather than the HTTPS endpoint

Same as here in Azure:
https://github.com/fermyon/installer/commit/b8b99da69cb359c29dd3393c74df215afc8255aa