### PR TITLE
Improve local setup script

### DIFF
--- a/local/start.sh
+++ b/local/start.sh
@@ -28,6 +28,19 @@ require consul
 require nomad
 require spin
 
+# NOTE(bacongobbler): nomad MUST run as root for the exec driver to work on Linux.
+# https://github.com/deislabs/hippo/blob/de73ae52d606c0a2351f90069e96acea831281bc/src/Infrastructure/Jobs/NomadJob.cs#L28
+# https://www.nomadproject.io/docs/drivers/exec#client-requirements
+case "$OSTYPE" in
+  linux*)
+    require sudo
+    SUDO="sudo --preserve-env=PATH"
+    ;;
+  *)
+    SUDO=
+    ;;
+esac
+
 cleanup() {
   echo
   echo "Shutting down services"
@@ -35,14 +48,6 @@ cleanup() {
   wait
 }
 trap cleanup EXIT
-
-# NOTE(bacongobbler): nomad MUST run as root for the exec driver to work on Linux.
-# https://github.com/deislabs/hippo/blob/de73ae52d606c0a2351f90069e96acea831281bc/src/Infrastructure/Jobs/NomadJob.cs#L28
-# https://www.nomadproject.io/docs/drivers/exec#client-requirements
-case "$OSTYPE" in
-  linux*) SUDO="sudo --preserve-env=PATH" ;;
-  *) SUDO= ;;
-esac
 
 # change to the directory of this script
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/local/start.sh
+++ b/local/start.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 case "${OSTYPE}" in
   linux* | darwin*)
     ;; # Linux, MacOS, and WSL2 can proceed
-  msys | cgywin)
+  msys | cygwin)
     echo "The ${OSTYPE} environment is not yet supported for the Fermyon platform."
     echo "But it will work within the Windows Subsystem for Linux."
     echo "See https://docs.microsoft.com/en-us/windows/wsl/install for details."

--- a/local/start.sh
+++ b/local/start.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Early exit for unsupported systems
 case "${OSTYPE}" in
-  linux* | darwin*)
+  linux-gnu* | darwin*)
     ;; # Linux, MacOS, and WSL2 can proceed
   msys | cygwin)
     echo "The ${OSTYPE} environment is not yet supported for the Fermyon platform."


### PR DESCRIPTION
- [fix(local): Typo in OSTYPE matching](https://github.com/fermyon/installer/commit/800384cc8082376a21a70b4b24f4b3b6fc2f194a)
  Rename cgywin to cygwin.
- [feat(local): Make OS check stricter](https://github.com/fermyon/installer/commit/a1e0149424fb967b7628b8760caaa967fe3196b2)
  Match exactly by `linux-gnu` rather than `linux`. Though I believe
  it's possible to run platform on `linux-musl` (Alpine Linux) the
  local script doesn't currently support it.

  Caveats:
  - bash isn't installed out of the box
  - binary version of Hippo isn't starting up (but hippo compiled from the sources seems to work)
  - sudo is only available in the community repo
  - consul is installed into /usr/sbin. In this case the whole script has to be run from sudo. Otherwise, consul won't be found in PATH.
- [feat(local): Require sudo on linux](https://github.com/fermyon/installer/commit/75ba91c1cb499ba0c67797e53e946e6120547de8)
  Also, require sudo before setting the trap to avoid cleanup call.