### PR TITLE
chore(local): Bump hippo to v0.19.0

### DIFF
--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -30,7 +30,7 @@ This example creates the following resources in the provided DigitalOcean projec
       value for constructing Hippo and Bindle URLs
   - 1 custom VPC
     - Name: `${var.vpc_name}` (default: `fermyon-vpc`)
-    - Note: if this is the first VPC in a region, it will be default VPC, so this VPC can't delete by `vagrant destroy`.
+    - Note: if this is the first VPC in a region, it will be default VPC, so this VPC can't delete by `terraform destroy`.
   - 6 custom firewalls
     - Inbound connections allowed for ports 22, 80 and 443
       - see `var.allowed_inbound_cidr_blocks` for allowed origin IP addresses
@@ -46,9 +46,12 @@ It is certainly advised to scope the allowed SSH CIDR block down to a single IP 
 
 As this example takes a stock Ubuntu 20.04 LTS and then proceeds to download Fermyon and Hashistack binaries,
 the default inbound CIDR block is likely necessary for first startup. After confirmation that
-Fermyon is up and running - and as long as subsequent apps/workloads won't need access to
-the broader internet - this value may be updated on a subsequent `terraform apply` if desired, e.g.
-`terraform apply -var=allowed_inbound_cidr_blocks=["75.75.75.75/32"]`.
+Fermyon is up and running - and as long as subsequent apps/workloads/ssh won't need access to
+the broader internet - this value may be updated on a subsequent `terraform apply` if desired, e.g.:
+
+```console
+terraform apply -var='allowed_inbound_cidr_blocks=["75.75.75.75/32"]' -var='allowed_ssh_cidr_blocks=["75.75.75.75/32"]'
+```
 
 # How to Deploy
 

--- a/digitalocean/terraform/variables.tf
+++ b/digitalocean/terraform/variables.tf
@@ -35,13 +35,13 @@ variable "dns_host" {
 }
 
 variable "allowed_ssh_cidr_blocks" {
-  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instance will allow SSH connections"
+  description = "A list of CIDR-formatted IP address ranges from which the DO Instance will allow SSH connections"
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "allowed_inbound_cidr_blocks" {
-  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instance will allow connections"
+  description = "A list of CIDR-formatted IP address ranges from which the DO Instance will allow connections"
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }

--- a/local/job/hippo.nomad
+++ b/local/job/hippo.nomad
@@ -12,7 +12,7 @@ variable "bindle_url" {
 
 variable "hippo_version" {
   type        = string
-  default     = "v0.17.0"
+  default     = "v0.19.0"
   description = "Hippo version"
 }
 
@@ -106,7 +106,7 @@ job "hippo" {
         Hippo__PlatformDomain = var.domain
         Scheduler__Driver     = "nomad"
         Nomad__Driver         = "raw_exec"
-        
+
         # Registration configuration
         Hippo__RegistrationMode            = var.registration_mode
         Hippo__Administrators__0__Username = var.registration_mode == "AdministratorOnly" ? var.admin_username : ""


### PR DESCRIPTION
Refs: #105.

Also, fix a few typos in digitalocean docs.
