### PR TITLE
adding vars for datacenter, version, tags, arch; cleaning up artifact…

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -20,7 +20,21 @@ The environment is ephemeral and will not persist any data.
 ```
 
 # Deploying to Fermyon
+## Using 'AdministratorOnly' registration mode (default)
+When using the `AdministratorOnly` registration mode, only a single
+administration account will be able to schedule workloads.  When running your
+Nomad job, you will have to pass in a value for the following variables:
+- `admin_username`
+- `admin_password`
 
+Using the provided `start.sh` script, you can set the environment variables
+`HIPPO_ADMIN_USERNAME` and `HIPPO_ADMIN_PASSWORD` to override the default 
+values (`admin`, and `password`, respectively); i.e.:
+```
+HIPPO_ADMIN_USERNAME=myclevername HIPPO_ADMIN_PASSWORD=<strong random password> ./start.sh
+```
+
+## Using 'Open' registration mode
 Once the script finishes deploying Fermyon services it will print a list of
 export statements. Copy these to your clipboard, leave the script running and
 open a new terminal window.

--- a/local/job/bindle.nomad
+++ b/local/job/bindle.nomad
@@ -1,3 +1,9 @@
+variable "datacenters" {
+  type = string
+  default = "dc1"
+  description = "a comma separated list of strings which determines which datacenters a service should be deployed to; i.e. \"dc1,dc2\".  String will be coerced to a list at evaluation."
+}
+
 variable "domain" {
   type        = string
   default     = "local.fermyon.link"
@@ -24,8 +30,14 @@ variable "arch" {
   }
 }
 
+variable "version" {
+  default = "v0.8.2"
+  description = "declares which release of bindle to target"
+  type = string
+}
+
 job "bindle" {
-  datacenters = ["dc1"]
+  datacenters = split(",", var.datacenters)
   type        = "service"
 
   group "bindle" {
@@ -58,9 +70,7 @@ job "bindle" {
       driver = "raw_exec"
 
       artifact {
-        source = lookup({
-          linux="https://raw.githubusercontent.com/fermyon/installer/93008bc6461076da5c5f7f99cffc3e68b1955a17/local/bindle/bindle-server"
-        }, var.os, "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-${var.os}-${var.arch}.tar.gz")
+        source = "https://bindle.blob.core.windows.net/releases/bindle-${var.version}-${var.os}-${var.arch}.tar.gz"
       }
 
       env {

--- a/local/job/traefik.nomad
+++ b/local/job/traefik.nomad
@@ -1,6 +1,12 @@
+variable "datacenters" {
+  type = string
+  default = "dc1"
+  description = "a comma separated list of strings which determines which datacenters a service should be deployed to; i.e. \"dc1,dc2\".  String will be coerced to a list at evaluation."
+}
+
 job "traefik" {
   region      = "global"
-  datacenters = ["dc1"]
+  datacenters = split(",", var.datacenters)
   type        = "service"
 
   group "traefik" {


### PR DESCRIPTION
This PR pulls some hard-coded values out into new vars to ease bootstrapping in environments which may already have services like Nomad, and Traefik with some configuration opinions already in place.

The scope is limited to just the local job definitions, but if approved, should be mirrored to the other jobs.